### PR TITLE
Scope mousemove listener to workspace container to exclude modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,11 @@
 	"author": "Bradley Wyatt",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^16.11.6",
-		"@typescript-eslint/eslint-plugin": "5.29.0",
-		"@typescript-eslint/parser": "5.29.0",
-		"builtin-modules": "3.3.0",
-		"esbuild": "0.17.3",
+		"@types/node": "^22.0.0",
+		"builtin-modules": "^4.0.0",
+		"esbuild": "^0.25.0",
 		"obsidian": "latest",
-		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"tslib": "^2.8.0",
+		"typescript": "^5.7.0"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ interface ExtendedWorkspaceSplit extends WorkspaceSplit {
   collapsed: boolean;
   expand: () => void;
   collapse: () => void;
+  resizeHandleEl: HTMLElement;
 }
 
 interface ExtendedWorkspaceRibbon extends WorkspaceRibbon {
@@ -57,8 +58,6 @@ export default class OpenSidebarHover extends Plugin {
   leftRibbon: ExtendedWorkspaceRibbon;
   leftSplitMouseEnterHandler: () => void;
   rightSplitMouseEnterHandler: () => void;
-  leftSplitMouseMoveHandler: () => void;
-  rightSplitMouseMoveHandler: () => void;
   workspaceChangeTimeout: NodeJS.Timeout | null = null;
   
   // Double-click tracking variables
@@ -99,6 +98,7 @@ export default class OpenSidebarHover extends Plugin {
 
     return false;
   }
+
 
   handleWorkspaceChange() {
     // Wait to ensure DOM is ready
@@ -184,42 +184,68 @@ export default class OpenSidebarHover extends Plugin {
 
   // Attach manually managed event listeners
   attachManualEvents() {
-    // Helper function to track events for cleanup
     const attach = (element: HTMLElement, type: string, handler: EventListener) => {
       element.addEventListener(type, handler);
       this.manualEvents.push({ element, type, handler });
     };
-    
-    // Implementation with hover class for right split
+
+    // Right split: mouseenter triggers expand when collapsed, maintains hover when expanded
     if (this.rightSplit?.containerEl) {
-      this.rightSplitMouseEnterHandler = () => { 
-        this.isHoveringRight = true; 
+      this.rightSplitMouseEnterHandler = () => {
+        if (this.settings.onlyWhenFocused && !document.hasFocus()) return;
+        this.isHoveringRight = true;
         this.rightSplit.containerEl.addClass('hovered');
+        if (this.settings.rightSidebar && this.rightSplit.collapsed && !this.isPinnedRight) {
+          setTimeout(() => {
+            if (this.isHoveringRight) {
+              if (this.settings.syncLeftRight) {
+                this.expandBoth();
+              } else {
+                this.expandRight();
+              }
+            }
+          }, this.settings.sidebarExpandDelay);
+        }
       };
       attach(this.rightSplit.containerEl, "mouseenter", this.rightSplitMouseEnterHandler);
-      
       attach(this.rightSplit.containerEl, "mouseleave", this.rightSplitMouseLeaveHandler);
-      
-      this.rightSplitMouseMoveHandler = () => this.rightSplit.containerEl.addClass('hovered');
-      attach(this.rightSplit.containerEl, "mousemove", this.rightSplitMouseMoveHandler);
+
+      // Resize handle as additional enter target for collapsed state
+      if (this.rightSplit.resizeHandleEl) {
+        attach(this.rightSplit.resizeHandleEl, "mouseenter", this.rightSplitMouseEnterHandler);
+      }
     }
-    
-    // Implementation with hover class for left split
-    if (this.leftRibbon && this.leftRibbon.containerEl) {
+
+    // Left ribbon: triggers left expand
+    if (this.leftRibbon?.containerEl) {
       attach(this.leftRibbon.containerEl, "mouseenter", this.leftRibbonMouseEnterHandler);
     }
-    
+
+    // Left split: mouseenter triggers expand when collapsed, maintains hover when expanded
     if (this.leftSplit?.containerEl) {
-      this.leftSplitMouseEnterHandler = () => { 
-        this.isHoveringLeft = true; 
+      this.leftSplitMouseEnterHandler = () => {
+        if (this.settings.onlyWhenFocused && !document.hasFocus()) return;
+        this.isHoveringLeft = true;
         this.leftSplit.containerEl.addClass('hovered');
+        if (this.settings.leftSidebar && this.leftSplit.collapsed && !this.isPinnedLeft) {
+          setTimeout(() => {
+            if (this.isHoveringLeft) {
+              if (this.settings.syncLeftRight) {
+                this.expandBoth();
+              } else {
+                this.expandLeft();
+              }
+            }
+          }, this.settings.sidebarExpandDelay);
+        }
       };
       attach(this.leftSplit.containerEl, "mouseenter", this.leftSplitMouseEnterHandler);
-      
       attach(this.leftSplit.containerEl, "mouseleave", this.leftSplitMouseLeaveHandler);
-      
-      this.leftSplitMouseMoveHandler = () => this.leftSplit.containerEl.addClass('hovered');
-      attach(this.leftSplit.containerEl, "mousemove", this.leftSplitMouseMoveHandler);
+
+      // Resize handle as additional enter target for collapsed state
+      if (this.leftSplit.resizeHandleEl) {
+        attach(this.leftSplit.resizeHandleEl, "mouseenter", this.leftSplitMouseEnterHandler);
+      }
     }
   }
 
@@ -286,8 +312,27 @@ export default class OpenSidebarHover extends Plugin {
       this.rightSplit = this.app.workspace.rightSplit as unknown as ExtendedWorkspaceSplit;
       this.leftRibbon = this.app.workspace.leftRibbon as unknown as ExtendedWorkspaceRibbon;
       
-      // Register auto-cleaned events using Obsidian's API
-      this.registerDomEvent(document, "mousemove", this.mouseMoveHandler);
+      // Collapse sidebars when mouse enters the root editing area
+      const rootSplitEl = (this.app.workspace.rootSplit as unknown as ExtendedWorkspaceSplit).containerEl;
+      this.registerDomEvent(rootSplitEl, 'mouseenter', () => {
+        if (this.settings.leftSidebar && !this.isPinnedLeft) {
+          this.isHoveringLeft = false;
+          this.leftSplit?.containerEl?.removeClass('hovered');
+          this.collapseLeft();
+        }
+        if (this.settings.rightSidebar && !this.isPinnedRight) {
+          this.isHoveringRight = false;
+          this.rightSplit?.containerEl?.removeClass('hovered');
+          this.collapseRight();
+        }
+      });
+
+      // Collapse when mouse leaves the window entirely
+      this.registerDomEvent(document, 'mouseleave', () => {
+        if (!this.isPinnedLeft) this.collapseLeft();
+        if (!this.isPinnedRight) this.collapseRight();
+      });
+
       this.registerDomEvent(document, "click", this.documentClickHandler);
       
       // To prevent plugin from breaking after workspace changes
@@ -344,6 +389,8 @@ export default class OpenSidebarHover extends Plugin {
         --sidebar-expand-delay: ${this.settings.sidebarExpandDelay}ms;
         --left-sidebar-max-width: ${this.settings.leftSidebarMaxWidth}px;
         --right-sidebar-max-width: ${this.settings.rightSidebarMaxWidth}px;
+        --left-trigger-width: ${this.settings.leftSideBarPixelTrigger}px;
+        --right-trigger-width: ${this.settings.rightSideBarPixelTrigger}px;
       }
       
       body {
@@ -355,9 +402,6 @@ export default class OpenSidebarHover extends Plugin {
     // Add the style element to the document head
     document.head.appendChild(styleEl);
   }
-
-  // Helpers
-  getEditorWidth = () => this.app.workspace.containerEl.clientWidth;
 
   expandRight() {
     // Start animation by expanding
@@ -460,70 +504,6 @@ export default class OpenSidebarHover extends Plugin {
     }
   }
   
-  // Event handlers
-  mouseMoveHandler = (event: MouseEvent) => {
-    // Skip hover detection if setting is enabled and window is not focused
-    if (this.settings.onlyWhenFocused && !document.hasFocus()) {
-      return;
-    }
-
-    const mouseX = event.clientX;
-
-    // Handle right sidebar hover
-    if (this.settings.rightSidebar) {
-      if (!this.isHoveringRight && this.rightSplit.collapsed && !this.isPinnedRight) {
-        const editorWidth = this.getEditorWidth();
-
-        this.isHoveringRight =
-          mouseX >= editorWidth - this.settings.rightSideBarPixelTrigger;
-
-        if (this.isHoveringRight && this.rightSplit.collapsed) {
-          setTimeout(() => {
-            if (this.isHoveringRight) {
-              if (this.settings.syncLeftRight) {
-                this.expandBoth();
-              } else {
-                this.expandRight();
-              }
-            }
-          }, this.settings.sidebarExpandDelay);
-        }
-
-        setTimeout(() => {
-          if (!this.isHoveringRight) {
-            this.collapseRight();
-          }
-        }, this.settings.sidebarDelay);
-      }
-    }
-    
-    // Handle left sidebar hover
-    if (this.settings.leftSidebar) {
-      if (!this.isHoveringLeft && this.leftSplit.collapsed && !this.isPinnedLeft) {
-        // Check if mouse is in the left trigger area
-        this.isHoveringLeft = mouseX <= this.settings.leftSideBarPixelTrigger;
-
-        if (this.isHoveringLeft && this.leftSplit.collapsed) {
-          setTimeout(() => {
-            if (this.isHoveringLeft) {
-              if (this.settings.syncLeftRight) {
-                this.expandBoth();
-              } else {
-                this.expandLeft();
-              }
-            }
-          }, this.settings.sidebarExpandDelay);
-        }
-
-        setTimeout(() => {
-          if (!this.isHoveringLeft) {
-            this.collapseLeft();
-          }
-        }, this.settings.sidebarDelay);
-      }
-    }
-  };
-
   rightSplitMouseLeaveHandler = (event: MouseEvent) => {
     // Don't process if we're leaving to the tab header container or a menu
     const target = event.relatedTarget as HTMLElement;

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ export default class OpenSidebarHover extends Plugin {
   leftRibbon: ExtendedWorkspaceRibbon;
   leftSplitMouseEnterHandler: () => void;
   rightSplitMouseEnterHandler: () => void;
+  private rightTriggerZoneEl: HTMLElement | null = null;
   workspaceChangeTimeout: NodeJS.Timeout | null = null;
   
   // Double-click tracking variables
@@ -214,6 +215,34 @@ export default class OpenSidebarHover extends Plugin {
       if (this.rightSplit.resizeHandleEl) {
         attach(this.rightSplit.resizeHandleEl, "mouseenter", this.rightSplitMouseEnterHandler);
       }
+
+      // Programmatic trigger zone at the right edge of the workspace.
+      // Unlike the left sidebar (which has the always-visible left ribbon as a
+      // trigger), the right sidebar has no equivalent element. When collapsed,
+      // its containerEl is effectively hidden, so mouseenter never fires. This
+      // thin absolutely-positioned div acts as the right-edge hover target.
+      //
+      // position:absolute requires the parent to be a positioning context.
+      // Obsidian's workspace container is position:static by default, so the
+      // trigger zone would anchor to a distant ancestor instead. Ensure the
+      // container is position:relative before appending.
+      const wsContainer = this.app.workspace.containerEl;
+      if (getComputedStyle(wsContainer).position === 'static') {
+        wsContainer.style.position = 'relative';
+      }
+      this.rightTriggerZoneEl = document.createElement('div');
+      this.rightTriggerZoneEl.className = 'right-sidebar-trigger-zone';
+      this.rightTriggerZoneEl.style.cssText = `
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: ${this.settings.rightSideBarPixelTrigger}px;
+        height: 100%;
+        z-index: 1;
+        pointer-events: auto;
+      `;
+      wsContainer.appendChild(this.rightTriggerZoneEl);
+      attach(this.rightTriggerZoneEl, 'mouseenter', this.rightSplitMouseEnterHandler);
     }
 
     // Left ribbon: triggers left expand
@@ -256,6 +285,12 @@ export default class OpenSidebarHover extends Plugin {
       element.removeEventListener(type, handler);
     });
     this.manualEvents = [];
+
+    // Remove trigger zone element
+    if (this.rightTriggerZoneEl) {
+      this.rightTriggerZoneEl.remove();
+      this.rightTriggerZoneEl = null;
+    }
     
     // Clean up hover classes
     if (this.rightSplit?.containerEl) {
@@ -315,13 +350,15 @@ export default class OpenSidebarHover extends Plugin {
       // Collapse sidebars when mouse enters the root editing area
       const rootSplitEl = (this.app.workspace.rootSplit as unknown as ExtendedWorkspaceSplit).containerEl;
       this.registerDomEvent(rootSplitEl, 'mouseenter', () => {
-        if (this.settings.leftSidebar && !this.isPinnedLeft) {
-          this.isHoveringLeft = false;
+        // Only collapse a sidebar if the mouse is NOT currently tracked as
+        // hovering over it. The isHoveringLeft/isHoveringRight flags are set
+        // by stable mouseenter/mouseleave handlers on the sidebar containers
+        // (which don't fire when moving between children).
+        if (this.settings.leftSidebar && !this.isPinnedLeft && !this.isHoveringLeft) {
           this.leftSplit?.containerEl?.removeClass('hovered');
           this.collapseLeft();
         }
-        if (this.settings.rightSidebar && !this.isPinnedRight) {
-          this.isHoveringRight = false;
+        if (this.settings.rightSidebar && !this.isPinnedRight && !this.isHoveringRight) {
           this.rightSplit?.containerEl?.removeClass('hovered');
           this.collapseRight();
         }
@@ -504,30 +541,17 @@ export default class OpenSidebarHover extends Plugin {
     }
   }
   
-  rightSplitMouseLeaveHandler = (event: MouseEvent) => {
-    // Don't process if we're leaving to the tab header container or a menu
-    const target = event.relatedTarget as HTMLElement;
-    if (target && (target.closest('.workspace-tab-header-container-inner') ||
-                  (target.hasClass && target.hasClass('menu')) ||
-                  target?.classList?.contains('menu') ||
-                  target?.closest('.menu'))) {
-      return;
-    }
-
-    // Don't collapse if window is not focused and setting is enabled
+  rightSplitMouseLeaveHandler = () => {
     if (this.settings.onlyWhenFocused && !document.hasFocus()) return;
-
-    // Don't collapse if user is actively editing (rename, menu open, etc.)
     if (this.isActivelyEditing()) return;
 
     if (this.settings.rightSidebar && !this.isPinnedRight) {
       this.isHoveringRight = false;
-      // Remove the hovered class
-      this.rightSplit.containerEl.removeClass('hovered');
 
       setTimeout(() => {
-        // Re-check editing state before collapsing
+        // Re-check: if mouse re-entered the sidebar, don't collapse
         if (!this.isHoveringRight && !this.isActivelyEditing()) {
+          this.rightSplit.containerEl.removeClass('hovered');
           if (this.settings.syncLeftRight && this.settings.leftSidebar) {
             this.collapseBoth();
           } else {
@@ -538,30 +562,17 @@ export default class OpenSidebarHover extends Plugin {
     }
   };
 
-  leftSplitMouseLeaveHandler = (event: MouseEvent) => {
-    // Don't process if we're leaving to the tab header container or a menu
-    const target = event.relatedTarget as HTMLElement;
-    if (target && (target.closest('.workspace-tab-header-container-inner') ||
-                  (target.hasClass && target.hasClass('menu')) ||
-                  target?.classList?.contains('menu') ||
-                  target?.closest('.menu'))) {
-      return;
-    }
-
-    // Don't collapse if window is not focused and setting is enabled
+  leftSplitMouseLeaveHandler = () => {
     if (this.settings.onlyWhenFocused && !document.hasFocus()) return;
-
-    // Don't collapse if user is actively editing (rename, menu open, etc.)
     if (this.isActivelyEditing()) return;
 
     if (this.settings.leftSidebar && !this.isPinnedLeft) {
       this.isHoveringLeft = false;
-      // Remove the hovered class
-      this.leftSplit.containerEl.removeClass('hovered');
 
       setTimeout(() => {
-        // Re-check editing state before collapsing
+        // Re-check: if mouse re-entered the sidebar, don't collapse
         if (!this.isHoveringLeft && !this.isActivelyEditing()) {
+          this.leftSplit.containerEl.removeClass('hovered');
           if (this.settings.syncLeftRight && this.settings.rightSidebar) {
             this.collapseBoth();
           } else {

--- a/styles.css
+++ b/styles.css
@@ -67,9 +67,14 @@ body {
     pointer-events: auto;
 }
 
-/* Allow hover detection for collapsed sidebars */
-.workspace-split.mod-left-split.is-collapsed,
-.workspace-split.mod-right-split.is-collapsed {
+/* Trigger zones for collapsed sidebars - ensures mouseenter fires */
+.open-sidebar-hover-plugin .workspace-split.mod-left-split.is-collapsed {
+    min-width: var(--left-trigger-width, 1px) !important;
+    pointer-events: auto;
+}
+
+.open-sidebar-hover-plugin .workspace-split.mod-right-split.is-collapsed {
+    min-width: var(--right-trigger-width, 1px) !important;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary

Replaces the global `document` mousemove pixel-detection approach with proper enter/leave event listeners scoped to workspace regions.

## Problem

The `mouseMoveHandler` was registered on `document`, so mouse movement inside Obsidian modals (Settings, community plugin browser, any `Modal` subclass) still triggered sidebar edge-detection and auto-expand.

## Approach

Instead of filtering out modal events from a global listener, this refactor eliminates the global listener entirely and uses **enter/leave events on the actual workspace DOM regions**:

- **`mouseenter` on left/right split containers** -- triggers expand when collapsed (with delay + sync support)
- **`mouseenter` on resize handles** -- additional collapsed-state trigger target
- **`mouseleave` on split containers** -- triggers collapse after delay (existing handlers, unchanged)
- **`mouseenter` on rootSplit** -- collapses non-pinned sidebars when mouse enters the editing area
- **`mouseenter` on left ribbon** -- triggers left expand (existing handler, unchanged)
- **`document mouseleave`** -- collapses when mouse leaves the window

### Right-edge trigger zone

The left sidebar has the always-visible left ribbon as a `mouseenter` target. The right sidebar has no equivalent element -- when collapsed, its `containerEl` is effectively hidden, so `mouseenter` never fires. To solve this, a thin absolutely-positioned div is created at the right edge of `workspace.containerEl` (width from `rightSideBarPixelTrigger` setting, full height, `z-index: 1`). It reuses the existing `rightSplitMouseEnterHandler` and is created/destroyed in `attachManualEvents`/`detachManualEvents`.

### CSS trigger zones

Collapsed sidebars get a `min-width` from the existing pixel trigger settings (via CSS variables `--left-trigger-width` / `--right-trigger-width`), providing additional hover surface.

### Why modals are excluded structurally

Obsidian renders modals in `.modal-container`, a sibling of `workspace.containerEl`. Since all listeners are scoped to workspace regions (splits, ribbon, rootSplit), modal mouse events never reach any handler. No polling, no DOM queries, no heuristics.

### What was removed

- `mouseMoveHandler` (global pixel-detection)
- `getEditorWidth` helper
- `leftSplitMouseMoveHandler` / `rightSplitMouseMoveHandler` (mousemove on splits for hover class)
- Unused eslint devDependencies (resolves all npm audit vulnerabilities)

Fixes bwya77/obsidian-quick-peek-sidebar#16
